### PR TITLE
Bug Fix: Escape backslash (\) by default

### DIFF
--- a/seclang/parser/scanner.go
+++ b/seclang/parser/scanner.go
@@ -106,6 +106,7 @@ func (s *Scanner) readString(delimiter ...rune) (string, error) {
 			case c == EOS:
 				return "", fmt.Errorf("unexpected EOS after %s", s.buffer.String())
 			default:
+				s.save('\\')
 				s.saveAndAdvance()
 			}
 		default:


### PR DESCRIPTION
This PR addresses the incorrect parsing of the SecLang Parser under for some Regex.

For example, before this PR, the Regex ```(?i:sleep\(\s*?\d*?\s*?\)|benchmark\(.*?\,.*?\))``` will be parse into ```(?i:sleep(s*?d*?s*?)|benchmark(.*?,.*?))```, which is incorrect. We propose a fix by escaping all backslash by default. 

Please tag a new release after merging. Appreciated!